### PR TITLE
TargetSDKVersionを35に上げる対応を実施

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,13 +7,13 @@ plugins {
 }
 
 android {
-    compileSdk 34
+    compileSdk 35
     namespace = "com.yuoyama12.decidepickingorderapp"
 
     defaultConfig {
         applicationId "com.yuoyama12.decidepickingorderapp"
         minSdk 21
-        targetSdk 34
+        targetSdk 35
         versionCode 4
         versionName "1.2.1"
 

--- a/app/src/main/java/com/yuoyama12/decidepickingorderapp/MainActivity.kt
+++ b/app/src/main/java/com/yuoyama12/decidepickingorderapp/MainActivity.kt
@@ -3,10 +3,12 @@ package com.yuoyama12.decidepickingorderapp
 import android.app.Activity
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.view.View
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import com.yuoyama12.decidepickingorderapp.databinding.ActivityMainBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -22,11 +24,25 @@ class MainActivity : AppCompatActivity() {
         setContentView(binding.root)
         setSupportActionBar(binding.actionBar)
 
-        // edge-to-edge対応のため、画面全体にpaddingを設ける。
+        // edge-to-edge対応のため、toolBarがあるtop以外の画面にpaddingを設ける。
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            view.setPadding(systemBars.left, 0, systemBars.right, systemBars.bottom)
+            insets
+        }
 
+        // toolBarに色がつけられないのでtoolBar代替用のViewを入れて
+        // スペースとして設ける。
+        addToolBarPadding()
+    }
+
+    private fun addToolBarPadding() {
+        val spacePadding = getToolBarSpacePaddingView(this)
+        ViewCompat.setOnApplyWindowInsetsListener(spacePadding) { view, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.updateLayoutParams {
+                height = systemBars.top
+            }
             insets
         }
     }
@@ -34,6 +50,9 @@ class MainActivity : AppCompatActivity() {
     companion object {
         fun getActionBar(activity: Activity): Toolbar =
             activity.findViewById(R.id.action_bar)
+
+        fun getToolBarSpacePaddingView(activity: Activity): View =
+            activity.findViewById(R.id.space_padding)
 
         fun createNavigationIcon(toolbar: Toolbar, onClick: () -> Unit) {
             toolbar.apply {

--- a/app/src/main/java/com/yuoyama12/decidepickingorderapp/MainActivity.kt
+++ b/app/src/main/java/com/yuoyama12/decidepickingorderapp/MainActivity.kt
@@ -3,7 +3,10 @@ package com.yuoyama12.decidepickingorderapp
 import android.app.Activity
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.yuoyama12.decidepickingorderapp.databinding.ActivityMainBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -14,9 +17,18 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
         setSupportActionBar(binding.actionBar)
+
+        // edge-to-edge対応のため、画面全体にpaddingを設ける。
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+
+            insets
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/yuoyama12/decidepickingorderapp/fragments/OrderDisplayFragment.kt
+++ b/app/src/main/java/com/yuoyama12/decidepickingorderapp/fragments/OrderDisplayFragment.kt
@@ -10,6 +10,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.yuoyama12.decidepickingorderapp.FlickListener
+import com.yuoyama12.decidepickingorderapp.MainActivity
 import com.yuoyama12.decidepickingorderapp.R
 import com.yuoyama12.decidepickingorderapp.databinding.FragmentOrderDisplayBinding
 import com.yuoyama12.decidepickingorderapp.preference.ColorSelectorPreference
@@ -51,6 +52,8 @@ class OrderDisplayFragment : Fragment() {
 
         val actionBar = activity?.findViewById<androidx.appcompat.widget.Toolbar>(R.id.action_bar)
         actionBar?.visibility = View.GONE
+        val toolBarSpacePaddingView = activity?.let { MainActivity.getToolBarSpacePaddingView(it) }
+        toolBarSpacePaddingView?.visibility = View.GONE
 
         val sharedPref = GeneralPreferencesFragment.getSharedPreference(requireContext())
         setVisibilityOfColorMarker(sharedPref)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,6 +6,15 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
+    <View
+        android:id="@+id/space_padding"
+        android:layout_width="match_parent"
+        android:background="@color/MyActionBarBackgroundColor"
+        android:layout_height="20dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"  />
+
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/action_bar"
         android:layout_width="match_parent"
@@ -14,7 +23,7 @@
         android:theme="@style/MyActionbar"
         android:elevation="4dp"
         android:stateListAnimator="@null"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/space_padding"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />


### PR DESCRIPTION
- targetSdkVersion, compileSdkVersionを35に上げる。
- Android15で適用されるedge-to-edgeへの対応

## イメージ
<img width=260 src="https://github.com/user-attachments/assets/41f5d73e-12f0-4e44-8e57-0f91ad393077"> 
