### PR TITLE
16KBページサイズのサポート対応を実施

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,13 +7,13 @@ plugins {
 }
 
 android {
-    compileSdk 35
+    compileSdk 36
     namespace = "com.yuoyama12.decidepickingorderapp"
 
     defaultConfig {
         applicationId "com.yuoyama12.decidepickingorderapp"
-        minSdk 21
-        targetSdk 35
+        minSdk 23
+        targetSdk 36
         versionCode 5
         versionName "1.2.2"
 
@@ -44,27 +44,26 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.13.1'
-    implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'com.google.android.material:material:1.12.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.8.4'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.4'
+    implementation 'androidx.core:core-ktx:1.17.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'com.google.android.material:material:1.13.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.9.4'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.4'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 
-    def nav_version = "2.7.7"
+    def nav_version = "2.9.5"
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
-    def room_version = "2.6.1"
+    def room_version = "2.8.3"
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
 
-    def hilt_version = "2.52"
+    def hilt_version = "2.57.2"
     implementation "com.google.dagger:hilt-android:$hilt_version"
     kapt "com.google.dagger:hilt-android-compiler:$hilt_version"
 
@@ -73,12 +72,12 @@ dependencies {
     implementation 'org.apache.xmlbeans:xmlbeans:3.0.2'
     implementation "org.apache.poi:poi-ooxml-schemas:4.0.1"
 
-    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'com.google.code.gson:gson:2.13.2'
 
     def preference_version = "1.2.1"
     implementation "androidx.preference:preference-ktx:$preference_version"
 
-    implementation "androidx.datastore:datastore-preferences:1.1.1"
+    implementation "androidx.datastore:datastore-preferences:1.1.7"
 
     implementation 'com.github.QuadFlask:colorpicker:0.0.15'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,15 @@
 buildscript {
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.4'
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.52'
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.7.7"
+        classpath 'com.android.tools.build:gradle:8.11.2'
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.57.2'
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.9.5"
     }
 }
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.2.2' apply false
-    id 'com.android.library' version '7.2.2' apply false
+    id 'com.android.application' version '8.11.2' apply false
+    id 'com.android.library' version '8.11.2' apply false
     id 'org.jetbrains.kotlin.android' version '2.0.0' apply false
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Jun 20 09:26:12 JST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### 主な対応内容

既存のライブラリがネイティブコードを使用していたため該当しそうなライブラリのバージョンを上げる
legacyライブラリは不要となったので削除
roomのライブラリがminSdkVersion23以上を要したためminSdkVersionをあげる
targetSdkVersionを36に対応させる

---

ビルドできるところまで確認済み。